### PR TITLE
[#13] LFAI Model Skeleton Upgrade, README Clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A LeapfrogAI API-compatible CTransformers wrapper for quantized model inferencin
 
 ### Run Locally
 
+For cloning a model locally and running the development backend.
+
 #### Clone Model Locally
 
 ```bash
@@ -29,6 +31,8 @@ python main.py
 
 #### Local Image Build and Run
 
+For local image building and running.
+
 ```bash
 docker build -t ghcr.io/defenseunicorns/leapfrogai/ctransformers:latest .
 docker run -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/ctransformers:latest
@@ -36,14 +40,17 @@ docker run -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/ctransformers:lates
 
 #### Remote Image Build and Run
 
+For pulling a tagged image from the main release repository.
+
 Where `<IMAGE_TAG>` is the released packages found [here](https://github.com/orgs/defenseunicorns/packages/container/package/leapfrogai%2Fctransformers).
 
 ```bash
-docker build -t ghcr.io/defenseunicorns/leapfrogai/ctransformers:<IMAGE_TAG> .
 docker run -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/ctransformers:<IMAGE_TAG>
 ```
 
 ### Docker Build and Push
+
+This is for pushing a new image tag to the repository. Beforehand, ensure you run a `git tag <IMAGE_TAG>`.
 
 ```bash
 make docker-build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A LeapfrogAI API-compatible CTransformers wrapper for quantized model inferencin
 
 ## Instructions
 
-### Clone model locally
+### Run Locally
+
+#### Clone Model Locally
 
 ```bash
 mkdir .model/
@@ -14,7 +16,7 @@ wget https://huggingface.co/TheBloke/mpt-7b-chat-GGML/resolve/main/mpt-7b-chat.g
 mv mpt-7b-chat.ggmlv0.q4_0.bin .model/mpt-7b-chat.ggmlv0.q4_0.bin
 ```
 
-### Run Locally
+#### Run Python Backend Locally
 
 ```bash
 python -m venv .venv
@@ -23,11 +25,22 @@ python -m pip install -r requirements-dev.txt
 python main.py
 ```
 
-### Docker Run Locally
+### Docker Run
+
+#### Local Image Build and Run
 
 ```bash
 docker build -t ghcr.io/defenseunicorns/leapfrogai/ctransformers:latest .
 docker run -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/ctransformers:latest
+```
+
+#### Remote Image Build and Run
+
+Where `<IMAGE_TAG>` is the released packages found [here](https://github.com/orgs/defenseunicorns/packages/container/package/leapfrogai%2Fctransformers).
+
+```bash
+docker build -t ghcr.io/defenseunicorns/leapfrogai/ctransformers:<IMAGE_TAG> .
+docker run -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/ctransformers:<IMAGE_TAG>
 ```
 
 ### Docker Build and Push

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -2,7 +2,7 @@ package:
   create:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/ctransformers"
-      version: 0.0.1
+      version: 0.0.2
       name: ctransformers
     max_package_size: "1000000000"
   deploy:
@@ -15,4 +15,4 @@ package:
       requests_gpu: 0
       name: ctransformers
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/ctransformers"
-      version: 0.0.1
+      version: 0.0.2

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -16,5 +16,5 @@ components:
     required: true
     import:
       name: model
-      url: oci://ghcr.io/defenseunicorns/leapfrogai/leapfrogai-model:0.3.3-skeleton
+      url: oci://ghcr.io/defenseunicorns/leapfrogai/leapfrogai-model:0.3.4-skeleton
 

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -1,7 +1,7 @@
 kind: ZarfPackageConfig
 metadata:
   name: ctransformers
-  version: 0.0.1
+  version: 0.0.2
   description: >
     ctransformers model
 


### PR DESCRIPTION
Cuts new patch version, 0.0.1 -> 0.0.2 due to model skeleton upgrade for Go API bug fix.
Adds better README instructions for local and remote running, development, and production pushes.