### PR TITLE
Replaces references to version with image_version

### DIFF
--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -2,7 +2,7 @@ package:
   create:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/ctransformers"
-      version: 0.2.0
+      image_version: 0.2.0
       name: ctransformers
     max_package_size: "1000000000"
   deploy:
@@ -15,4 +15,4 @@ package:
       requests_gpu: 0
       name: ctransformers
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/ctransformers"
-      version: 0.2.0
+      image_version: 0.2.0


### PR DESCRIPTION
Replaces references to version with image_version to prevent the need to manually provide the variable.